### PR TITLE
[FIX] : 🐛  데이터가 없을 때 map에 대한 예외처리

### DIFF
--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -36,7 +36,7 @@ const Feed = () => {
     <UI.StWrapperBlock>
       <FeedTitle onClick={categoryPlusHandler} />
       <UI.StFeedBlock>
-        {feed.map((category: Category) => {
+        {feed?.map((category: Category) => {
           return (
             <CategoryBox
               key={category.categoryId}


### PR DESCRIPTION
feed 값이 없을 때, map함수에 대한 예외처리로 옵셔널 체이닝 추가했습니다. 