### PR TITLE
Server API <---> Calendar Type 간 프로퍼티 명 통일 

### DIFF
--- a/src/api/hooks/Main/useGetMain.ts
+++ b/src/api/hooks/Main/useGetMain.ts
@@ -5,9 +5,13 @@ import api from '../../axios/api';
 import { getCookie } from '../../auth/CookieUtils';
 import jwtDecode, { JwtPayload } from 'jwt-decode';
 
-const useGetMain = (type: boolean) => {
-  const today = new Date();
+interface GetMainProps {
+  type: boolean;
+  year: string;
+  month: string;
+}
 
+const useGetMain = ({ type, year, month }: GetMainProps) => {
   const { data, isLoading } = useQuery({
     queryKey: [keys.GET_MAIN, type],
     queryFn: async () => {
@@ -17,16 +21,12 @@ const useGetMain = (type: boolean) => {
 
       if (type === false) {
         const data = await api.get(
-          `/totalSchedule/${teamId}?year=${today.getFullYear()}&month=${
-            today.getMonth() + 1
-          }`
+          `/totalSchedule/${teamId}?year=${year}&month=${month}`
         );
         return data.data.main;
       } else if (type === true) {
         const data = await api.get(
-          `/totalVacation/${teamId}?year=${today.getFullYear()}&month=${
-            today.getMonth() + 1
-          }`
+          `/totalVacation/${teamId}?year=${year}&month=${month}`
         );
         return data.data.main.vacation;
       }

--- a/src/api/hooks/Main/usePostVacation.ts
+++ b/src/api/hooks/Main/usePostVacation.ts
@@ -11,7 +11,7 @@ interface Paylaod {
     location?: string;
     content?: string;
     ref?: string[]; //멘션
-    file?: File | string;
+    file?: File[] | string;
     eventType?: string;
     startTime?: string;
   };

--- a/src/api/hooks/Main/usePostschedule.ts
+++ b/src/api/hooks/Main/usePostschedule.ts
@@ -5,15 +5,17 @@ import { keys } from '../../utils/createQueryKey';
 
 interface Paylaod {
   postInfo?: {
-    startDay?: string;
-    endDay?: string;
+    Id?: string | number;
+    calendarId?: string;
     title?: string;
+    body?: string;
+    start?: Date;
+    end?: Date;
+    attendees?: string[];
     location?: string;
-    content?: string;
-    ref?: string[]; //멘션
-    file?: File | string;
-    eventType?: string;
-    startTime?: string;
+    userId?: string;
+    userName?: string;
+    fileList?: File[] | undefined;
   };
   url: string;
 }
@@ -22,7 +24,7 @@ const usePostschedule = () => {
   const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: async (payload: Paylaod) => {
-      console.log(payload);
+      console.log('payload', payload);
 
       const formData = getFormData(payload);
       const data = await api.post(`/${payload.url}`, formData, {
@@ -30,10 +32,14 @@ const usePostschedule = () => {
           'Content-Type': 'multipart/form-data',
         },
       });
+      console.log('data', data);
       return data;
     },
     onSuccess: () => {
       queryClient.invalidateQueries([keys.GET_MAIN, false]);
+    },
+    onError: () => {
+      console.log('test');
     },
   });
 
@@ -43,51 +49,58 @@ const usePostschedule = () => {
 export default usePostschedule;
 
 const getFormData = (payload: Paylaod): FormData | undefined => {
+  const start = payload.postInfo?.start?.toString();
+  const end = payload.postInfo?.end?.toString();
+  const formData = new FormData();
   switch (payload.url) {
     case 'meeting': {
-      const formData = new FormData();
-      formData.append('file', payload.postInfo?.file || '');
-      formData.append('startDay', payload.postInfo?.startDay || '');
-      formData.append('startTime', payload.postInfo?.startTime || '');
+      payload.postInfo?.fileList?.map((item, index) => formData.append('file', item));
+      formData.append('start', start || '');
+      formData.append('end', end || '');
       formData.append('title', payload.postInfo?.title || '');
-      formData.append('content', payload.postInfo?.content || '');
-      formData.append('file', payload.postInfo?.location || '');
-      payload.postInfo?.ref?.map((item, index) => formData.append(`ref[${index}]`, item));
-      formData.append('eventType', payload.postInfo?.eventType || '');
+      formData.append('body', payload.postInfo?.body || '');
+      formData.append('calendarId', payload.postInfo?.calendarId || '');
       formData.append('location', payload.postInfo?.location || '');
+      payload.postInfo?.attendees?.map((item, index) =>
+        formData.append(`attendees[${index}]`, item)
+      );
+
       return formData;
     }
 
     case 'report': {
-      const formData = new FormData();
       formData.append('title', payload.postInfo?.title || '');
-      formData.append('content', payload.postInfo?.content || '');
-      payload.postInfo?.ref?.map((item, index) => formData.append(`ref[${index}]`, item));
-      formData.append('file', payload.postInfo?.file || '');
-      formData.append('enrollDay', payload.postInfo?.startDay || '');
+      formData.append('body', payload.postInfo?.body || '');
+      payload.postInfo?.attendees?.map((item, index) =>
+        formData.append(`attendees[${index}]`, item)
+      );
+      payload.postInfo?.fileList?.map((item, index) => formData.append('file', item));
+      formData.append('start', start || '');
       return formData;
     }
 
     case 'other': {
-      const formData = new FormData();
-      formData.append('startDay', payload.postInfo?.startDay || '');
-      formData.append('endDay', payload.postInfo?.endDay || '');
+      formData.append('start', start || '');
+      formData.append('end', end || '');
       formData.append('title', payload.postInfo?.title || '');
-      formData.append('content', payload.postInfo?.content || '');
-      payload.postInfo?.ref?.map((item, index) => formData.append(`ref[${index}]`, item));
-      formData.append('file', payload.postInfo?.file || '');
+      formData.append('body', payload.postInfo?.body || '');
+      payload.postInfo?.attendees?.map((item, index) =>
+        formData.append(`attendees[${index}]`, item)
+      );
+      payload.postInfo?.fileList?.map((item, index) => formData.append('file', item));
       return formData;
     }
 
     case 'schedule': {
-      const formData = new FormData();
-      formData.append('startDay', payload.postInfo?.startDay || '');
-      formData.append('endDay', payload.postInfo?.endDay || '');
+      formData.append('start', start || '');
+      formData.append('end', end || '');
       formData.append('title', payload.postInfo?.title || '');
       formData.append('location', payload.postInfo?.location || '');
-      formData.append('content', payload.postInfo?.content || '');
-      payload.postInfo?.ref?.map((item, index) => formData.append(`ref[${index}]`, item));
-      formData.append('file', payload.postInfo?.file || '');
+      formData.append('body', payload.postInfo?.body || '');
+      payload.postInfo?.attendees?.map((item, index) =>
+        formData.append(`attendees[${index}]`, item)
+      );
+      payload.postInfo?.fileList?.map((item, index) => formData.append('file', item));
       return formData;
     }
 

--- a/src/components/Main/DocumentForm/ScheduleFormat/ScheduleFormat.tsx
+++ b/src/components/Main/DocumentForm/ScheduleFormat/ScheduleFormat.tsx
@@ -21,12 +21,16 @@ import { ErrorData, ScheduleProps } from '../commonInterface';
 import { ChangeTabContext } from '../../../../api/hooks/Main/useTabContext';
 import Swal from 'sweetalert2';
 
-const ScheduleFormat = ({ props, onReturnHandler, onCancelHandler }: ScheduleProps) => {
+const ScheduleFormat = ({
+  props,
+  onReturnHandler,
+  onCancelHandler,
+  propsRef,
+}: ScheduleProps) => {
   const mutation = usePostschedule();
   const [zoomClick, setZoomClick] = useState(false);
   const [tab] = useContext(ChangeTabContext);
-  const { data, isLoading } = useGetTeamInfo();
-  const [FormFiles, SetFormFile] = useState<File>();
+  const [FormFiles, SetFormFile] = useState<File[]>();
 
   const token = getCookie('token');
   const decoded = token && jwtDecode<JwtPayload>(token);
@@ -39,7 +43,7 @@ const ScheduleFormat = ({ props, onReturnHandler, onCancelHandler }: SchedulePro
   const [content, contentHandler, setContentValue] = useTextarea();
 
   useEffect(() => {
-    console.log('props', props.userName);
+    console.log('props', props);
     props.title !== undefined && setTitleHanlderValue(props.title?.split('-')[0]);
     props.userName !== undefined && setUserNameInputValue(props.userName);
     props.isReadOnly !== undefined && setDisable(props.isReadOnly);
@@ -60,7 +64,7 @@ const ScheduleFormat = ({ props, onReturnHandler, onCancelHandler }: SchedulePro
         if (result.isConfirmed) {
           const newProps = {
             ...props,
-            file: FormFiles,
+            fileList: FormFiles,
             attendees: mention,
             body: content,
             title: title,
@@ -111,7 +115,7 @@ const ScheduleFormat = ({ props, onReturnHandler, onCancelHandler }: SchedulePro
   };
 
   return (
-    <styles.StContainer ref={props.propsRef}>
+    <styles.StContainer ref={propsRef}>
       <ToastContainer />
       <styles.StTitleBlock>
         <styles.StTitleContentBlock>
@@ -188,12 +192,7 @@ const ScheduleFormat = ({ props, onReturnHandler, onCancelHandler }: SchedulePro
           </styles.StOpenButton>
         </styles.StOpenBlock>
         <styles.StFileBlock>
-          <FileUpload
-            fileName={props.fileName}
-            fileLocation={props.fileLocation}
-            onFileHandler={SetFormFile}
-            disable={disable}
-          />
+          <FileUpload onFileHandler={SetFormFile} disable={disable} files={props.files} />
         </styles.StFileBlock>
       </styles.StContentBlock>
 

--- a/src/components/Main/DocumentForm/VacationFormat/VacationFormat.tsx
+++ b/src/components/Main/DocumentForm/VacationFormat/VacationFormat.tsx
@@ -17,9 +17,14 @@ import { ErrorData, ScheduleProps } from '../commonInterface';
 import { ChangeTabContext } from '../../../../api/hooks/Main/useTabContext';
 import Swal from 'sweetalert2';
 
-const VacationFormat = ({ props, onReturnHandler, onCancelHandler }: ScheduleProps) => {
+const VacationFormat = ({
+  props,
+  onReturnHandler,
+  onCancelHandler,
+  propsRef,
+}: ScheduleProps) => {
   const mutation = usePostVacation();
-  const [FormFiles, SetFormFile] = useState<File>();
+  const [FormFiles, SetFormFile] = useState<File[]>();
   const [tab] = useContext(ChangeTabContext);
 
   const SaveClickHandler = () => {
@@ -97,7 +102,7 @@ const VacationFormat = ({ props, onReturnHandler, onCancelHandler }: SchedulePro
 
   console.log('disable', disable);
   return (
-    <styles.StContainer ref={props.propsRef}>
+    <styles.StContainer ref={propsRef}>
       <ToastContainer />
       <styles.StTitleBlock>
         <styles.StTitleContentBlock>

--- a/src/components/Main/DocumentForm/commonInterface.ts
+++ b/src/components/Main/DocumentForm/commonInterface.ts
@@ -1,23 +1,26 @@
 export interface ScheduleProps {
   props: {
-    id?: number | string;
+    Id?: string | number;
     calendarId?: string;
     title?: string;
-    userName?: string;
+    body?: string;
     start?: Date;
     end?: Date;
-    body?: string;
     attendees?: string[];
-    propsRef?: React.RefObject<HTMLDivElement>;
-    userId?: string;
-    isReadOnly?: boolean;
-    ref?: string[];
-    file?: File | string;
-    backgroundColor?: string;
     location?: string;
-    fileLocation?: string;
-    fileName?: string;
+    userId?: string;
+    userName?: string;
+    typeDetail?: string;
+    backgroundColor?: string;
+    files?: [
+      {
+        fileLocation?: string;
+        fileName?: string;
+      }
+    ];
+    isReadOnly?: boolean;
   };
+  propsRef?: React.RefObject<HTMLDivElement>;
   onReturnHandler?: React.Dispatch<React.SetStateAction<boolean>>;
   onCancelHandler?: () => void;
 }

--- a/src/components/Main/DocumentForm/components/FileUpload/FileUpload.tsx
+++ b/src/components/Main/DocumentForm/components/FileUpload/FileUpload.tsx
@@ -5,45 +5,64 @@ import * as styles from './styles';
 import { nanoid } from 'nanoid';
 
 interface FileUploadProps {
-  onFileHandler: React.Dispatch<React.SetStateAction<File | undefined>>;
+  onFileHandler: React.Dispatch<React.SetStateAction<File[] | undefined>>;
   disable?: boolean;
+  files?: [
+    {
+      fileLocation?: string;
+      fileName?: string;
+    }
+  ];
+}
+
+interface fileType {
   fileLocation?: string;
   fileName?: string;
 }
+
 const FileUpload = (props: FileUploadProps) => {
-  const [files, setFiles] = useState<File>();
-  const [fileNames, setFileNames] = useState<string[]>([]);
+  const [files, setFiles] = useState<File[]>();
+  const [fileList, setFileList] = useState<fileType[]>([]);
   const ChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.preventDefault();
+    const uploadFiles = e.target.files;
+    if (uploadFiles) {
+      const newFileList = Array.from(files || []); // 기존의 FileList를 배열로 변환
+      const fileName = [];
+      for (let i = 0; i < uploadFiles.length; i++) {
+        // 새로운 파일들을 배열에 추가
+        newFileList.push(uploadFiles[i]);
+        fileName.push({ fileName: uploadFiles[i].name, fileLocation: '' });
+      }
+      props.onFileHandler(newFileList);
+      setFiles(newFileList);
 
-    if (e.target.files) {
-      const uploadFile = e.target.files[0];
-      setFiles(uploadFile);
-      const newFiles = [...fileNames, e.target.files[0].name];
-      setFileNames(newFiles);
-      props.onFileHandler(uploadFile);
+      const newFileName = [...fileList, ...fileName];
+      setFileList(newFileName);
     }
   };
-
+  console.log('fileList', fileList);
   useEffect(() => {
-    if (props.fileName !== undefined) {
-      const newFileName = [props.fileName];
-      setFileNames(newFileName);
+    if (props.files !== undefined) {
+      setFileList(props.files);
+    } else {
+      setFileList([]);
     }
-  }, [props.fileName]);
+  }, [props.files]);
 
   return (
     <styles.StContainer>
       <FolderIcon />
-      {fileNames?.map(item => {
-        if (item !== '') {
+      {fileList?.map(item => {
+        if (item.fileLocation !== '') {
           return (
             <styles.StTagBlock key={nanoid()}>
-              <a href={props.fileLocation}> {item}</a>
+              <a href={item.fileLocation}>{item.fileName}</a>
             </styles.StTagBlock>
           );
         } else {
-          return null;
+          console.log('asdas');
+          return <styles.StTagBlock key={nanoid()}>{item.fileName}</styles.StTagBlock>;
         }
       })}
 
@@ -52,7 +71,7 @@ const FileUpload = (props: FileUploadProps) => {
           <styles.StPlusLabel htmlFor="FileInput">
             <HiOutlinePlusSm size="25px" />
           </styles.StPlusLabel>
-          <styles.StInput type="file" id="FileInput" onChange={ChangeHandler} />
+          <styles.StInput type="file" id="FileInput" multiple onChange={ChangeHandler} />
         </>
       )}
     </styles.StContainer>

--- a/src/components/OneWeekCalendar/OneWeekCalendar.tsx
+++ b/src/components/OneWeekCalendar/OneWeekCalendar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import * as UI from './style';
-import oneWeekCalendar from '../../assets/images/oneWeekCalendar.jpg';
+import oneWeekCalendar from '../../assets/images/OneWeekCalendar.jpg';
 
 const OneWeekCalendar = () => {
   return (

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -11,7 +11,12 @@ export const CalendarContext = createContext<Partial<EventObject>[]>([]);
 
 const Main = () => {
   const [tab] = useContext(ChangeTabContext);
-  const { data, isLoading } = useGetMain(tab);
+  const today = new Date();
+  const { data, isLoading } = useGetMain({
+    type: tab,
+    year: today.getFullYear().toString(),
+    month: (today.getMonth() + 1).toString(),
+  });
   const [filterData, setFilterData] = useState<Partial<EventObject>[]>([]);
 
   useEffect(() => {

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, createContext, useState, useContext } from 'react';
 import { SubMain } from '../SubMain/SubMain';
 import useGetMain from '../../api/hooks/Main/useGetMain';
-import { ScheduleProps } from '../SubMain/interfaces';
+import { CalendarProps, ScheduleProps } from '../SubMain/interfaces';
 import { settingSchedule, settingVacation } from '../SubMain/utils';
 import { EventObject } from '@toast-ui/calendar/types/types/events';
 import { StWrap, StTabButton, StButtonBlcok } from './styles';
@@ -19,40 +19,46 @@ const Main = () => {
   });
   const [filterData, setFilterData] = useState<Partial<EventObject>[]>([]);
 
+  console.log(data);
   useEffect(() => {
     if (tab === false) {
-      const issues: Partial<EventObject>[] = data?.issue?.map((issue: ScheduleProps) =>
+      const issues: Partial<EventObject>[] = data?.issue?.map((issue: CalendarProps) =>
         settingSchedule(issue)
       );
       const schedules: Partial<EventObject>[] = data?.schedule?.map(
-        (schedule: ScheduleProps) => settingSchedule(schedule)
+        (schedule: CalendarProps) => settingSchedule(schedule)
       );
-      const reports: Partial<EventObject>[] = data?.report?.map((report: ScheduleProps) =>
+      const reports: Partial<EventObject>[] = data?.report?.map((report: CalendarProps) =>
         settingSchedule(report)
       );
-      const others: Partial<EventObject>[] = data?.other?.map((other: ScheduleProps) =>
+      const others: Partial<EventObject>[] = data?.other?.map((other: CalendarProps) =>
         settingSchedule(other)
       );
 
       const meetings: Partial<EventObject>[] = data?.meeting?.map(
-        (meeting: ScheduleProps) => settingSchedule(meeting)
+        (meeting: CalendarProps) => settingSchedule(meeting)
+      );
+
+      const events: Partial<EventObject>[] = data?.event?.map((event: CalendarProps) =>
+        settingSchedule(event)
       );
 
       const meetingReports: Partial<EventObject>[] = data?.meetingReport?.map(
-        (meetingReport: ScheduleProps) => settingSchedule(meetingReport)
+        (meetingReport: CalendarProps) => settingSchedule(meetingReport)
       );
 
-      const events: Partial<EventObject>[] = [];
-      issues !== undefined && events.push(...issues);
-      schedules !== undefined && events.push(...schedules);
-      reports !== undefined && events.push(...reports);
-      others !== undefined && events.push(...others);
-      meetings !== undefined && events.push(...meetings);
-      meetingReports !== undefined && events.push(...meetingReports);
-      setFilterData(events);
+      const eventList: Partial<EventObject>[] = [];
+      issues !== undefined && eventList.push(...issues);
+      schedules !== undefined && eventList.push(...schedules);
+      reports !== undefined && eventList.push(...reports);
+      others !== undefined && eventList.push(...others);
+      events !== undefined && eventList.push(...events);
+      meetings !== undefined && eventList.push(...meetings);
+      meetingReports !== undefined && eventList.push(...meetingReports);
+      setFilterData(eventList);
     } else {
       const events: Partial<EventObject>[] = [];
-      const vacations: Partial<EventObject>[] = data?.map((vacation: ScheduleProps) =>
+      const vacations: Partial<EventObject>[] = data?.map((vacation: CalendarProps) =>
         settingVacation(vacation)
       );
       vacations !== undefined && events.push(...vacations);

--- a/src/pages/SubMain/Detail/Detail.tsx
+++ b/src/pages/SubMain/Detail/Detail.tsx
@@ -31,8 +31,8 @@ function Detail({ props }: ScheduleProps) {
   const [tab] = useContext(ChangeTabContext);
   const SaveClickHandler = () => {
     const newData = postFormat(tab, props);
-    console.log(newData);
-    mutation.mutate({ ...newData });
+    // console.log(newData);
+    // mutation.mutate({ ...newData });
   };
 
   const [author, autherHandler] = useInput();

--- a/src/pages/SubMain/SubMain.tsx
+++ b/src/pages/SubMain/SubMain.tsx
@@ -139,6 +139,7 @@ export function SubMain({ view }: { view: ViewType }) {
     const userId = decoded ? decoded.userId : '';
 
     const newData = {
+      id: res.id,
       calendarId: res.calendarId,
       title: res.title,
       start: res.start,
@@ -150,11 +151,9 @@ export function SubMain({ view }: { view: ViewType }) {
       backgroundColor: getScheduleColor(tab, res.calendarId),
       location: res.location,
       userName: user.userInfo.userName,
-      fileName: '',
-      fileLocation: '',
+      files: undefined,
     };
 
-    console.log('newData', newData);
     setClickData(newData);
     setClickDetail(true);
     setClickEvent(res);
@@ -200,6 +199,7 @@ export function SubMain({ view }: { view: ViewType }) {
     console.log('Event Info : ', res.event);
     console.groupEnd();
 
+    console.log(schedules);
     for (let i = 0; i < schedules.length; i++) {
       if (schedules[i].id === res.event.id) {
         setClickData(schedules[i]);
@@ -256,7 +256,6 @@ export function SubMain({ view }: { view: ViewType }) {
   };
 
   const onDeleteEvent = () => {
-    console.log('cancel');
     clickEvent && getCalInstance().deleteEvent(clickEvent.id, clickEvent?.calendarId);
     setClickDetail(false);
   };
@@ -329,13 +328,15 @@ export function SubMain({ view }: { view: ViewType }) {
         <TodaySchedules todayData={todayData} />
       ) : tab === false ? (
         <ScheduleFormat
-          props={{ ...clickData, propsRef: detailRef }}
+          props={{ ...clickData }}
+          propsRef={detailRef}
           onReturnHandler={setClickDetail}
           onCancelHandler={onDeleteEvent}
         />
       ) : (
         <VacationFormat
-          props={{ ...clickData, propsRef: detailRef }}
+          props={{ ...clickData }}
+          propsRef={detailRef}
           onReturnHandler={setClickDetail}
           onCancelHandler={onDeleteEvent}
         />

--- a/src/pages/SubMain/TodayScheduels/TodaySchedules.tsx
+++ b/src/pages/SubMain/TodayScheduels/TodaySchedules.tsx
@@ -55,7 +55,7 @@ const TodaySchedules = (props: TodaysProps) => {
                     </styles.StBlock>
                   </styles.StContentBlock>
                   <styles.StIconBlock>
-                    <div>{item.fileLocation && <FolderIcon />}</div>
+                    <div>{item.files && <FolderIcon />}</div>
                     <div style={{ marginBottom: '-5px' }}>
                       {item.attendees && <TagIcon />}
                     </div>

--- a/src/pages/SubMain/interfaces.ts
+++ b/src/pages/SubMain/interfaces.ts
@@ -52,7 +52,8 @@ export interface InitialCalendar {
 }
 
 export interface CalendarProps {
-  id?: number | string;
+  id?: string | number;
+  Id?: string | number;
   calendarId?: string;
   title?: string;
   body?: string;
@@ -62,10 +63,15 @@ export interface CalendarProps {
   location?: string;
   userId?: string;
   userName?: string;
-  file?: string | File;
-  fileLocation?: string;
-  fileName?: string;
+  typeDetail?: string;
+  files?: [
+    {
+      fileLocation?: string;
+      fileName?: string;
+    }
+  ];
 
+  fileList?: File[] | undefined; //서버에서 정보 받을 때,
   color?: string;
   backgroundColor?: string;
   dragBackgroundColor?: string;


### PR DESCRIPTION
1. Calendar Event 에 맞춰서 Server API 수정을 했습니다.
  - 기존에 API 설계 miss로 중간에 library <--->server 간에 이름 변경이 보일러 플레이트를 일으켜 
    Calendar Type 기준으로 이름을 모두 변경했습니다. 

2. 파일 업로드 시, 여러개가 업데이트 되도록 수정했습니다. 
  - input 태그 속성의 multiple로 변경해서 fileList를 받아 해당 내용을 server로 보내도록 수정했습니다. 
  
3. 일정 탭란에서  기존에 있던 'other'의 역할 이 변경되었습니다. 
 - 기존 other : 결제 요청이 있는것들 중, select box에 없는 내용
 - 변경 other :결제 요청서 
 - 기존 'other' 자리에는 'event'라는 신규 항목이 추가 되었습니다. 
 - event 는 결제가 없고, 달력에만 내용이 표시됩니다. 