### PR TITLE
HOTFIX / 내가올린파일 디테일 문제 수정

### DIFF
--- a/src/components/UploadedFileTab/UploadedDetail/UploadedDetail.tsx
+++ b/src/components/UploadedFileTab/UploadedDetail/UploadedDetail.tsx
@@ -13,7 +13,7 @@ const UploadedDetail = ({ data, isLoading, type, closeModal }: DetailProps) => {
       break;
     }
     case 'myfiles': {
-      files = data.myfile;
+      files = data.detail;
       break;
     }
     case 'reportfiles': {

--- a/src/components/UploadedFileTab/interfaces.ts
+++ b/src/components/UploadedFileTab/interfaces.ts
@@ -36,7 +36,7 @@ interface Detail {
 export interface DetailProps {
   data: {
     meetingfile: Detail;
-    myfile: Detail;
+    detail: Detail;
     reportfile: Detail;
   };
   isLoading: boolean;


### PR DESCRIPTION
API 테이블 변경내용 적용 누락으로 인한 작동 오류 해결.

파일객체의 키값이 변경된 것에 대한 누락이 있었음.

```tsx
  switch (type) {
    case 'meetingfiles': {
      files = data.meetingfile;
      break;
    }
    case 'myfiles': {
      files = data.detail;
      break;
    }
    case 'reportfiles': {
      files = data.reportfile;
      break;
    }
  }
```

 `files = data.detail;`부분이 ` files = data.myfile;` 로 되어있었다.

#201