### PR TITLE
Refactoring/user feedback

### DIFF
--- a/src/api/hooks/Vacation/usePutDecision.ts
+++ b/src/api/hooks/Vacation/usePutDecision.ts
@@ -1,21 +1,62 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import apis from '../../axios/api';
 import { keys } from '../../utils/createQueryKey';
+import Swal from 'sweetalert2';
+import { AxiosError } from 'axios';
+import { VacationPayload } from '../../../components/VacationTab/interfaces';
 
-interface Payload {
-  status: 'submit' | 'accept' | 'deny';
-  Id: number;
+interface ErrorData {
+  success: boolean;
+  errorMessage: string;
+}
+
+interface SuccessData {
+  message: string;
 }
 
 export const usePutDecision = () => {
   const queryClient = useQueryClient();
   const { mutate } = useMutation({
-    mutationFn: async (payload: Payload) => {
+    mutationFn: async (payload: VacationPayload) => {
       const result = await apis.put(`/vacation/${payload.Id}/${payload.status}`);
       return result.data;
     },
-    onSuccess: () => {
+
+    // 요청 성공 시
+    onSuccess: (data: SuccessData, payload) => {
+      // 승인, 거절 메세지 세팅
+      const titleMessage =
+        data.message === '휴가가 등록되었습니다.'
+          ? `${payload.userName} 님의 휴가가 등록되었습니다.`
+          : `${payload.userName} 님의 휴가가 반려되었습니다.`;
+
+      // 승인, 거절 알럿
+      Swal.fire({
+        position: 'center',
+        icon: 'success',
+        title: titleMessage,
+        showConfirmButton: false,
+        timer: 1000,
+      });
       queryClient.invalidateQueries([keys.GET_VACATION_LIST]);
+    },
+
+    // 요청 실패 시
+    onError: (error: AxiosError<ErrorData>, payload) => {
+      // 에러메세지 세팅
+      const errorMessage =
+        error.response?.data.errorMessage === '남은 연차 일수가 부족합니다.'
+          ? `<span style="font-size: 25px;">${payload.userName}님의 ${error.response?.data.errorMessage}</span>`
+          : error.response?.data.errorMessage;
+
+      // 요청 실패 알럿
+      Swal.fire({
+        position: 'center',
+        icon: 'error',
+        html: errorMessage,
+        showConfirmButton: false,
+        timer: 1000,
+      });
     },
   });
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -10,9 +10,13 @@ import { getCookie } from '../../api/auth/CookieUtils';
 import jwtDecode from 'jwt-decode';
 import { useNavigate } from 'react-router-dom';
 import { BsPencilSquare } from '@react-icons/all-files/bs/BsPencilSquare';
+import { recoilTabState } from '../../states/recoilTabState';
+import { useRecoilValue } from 'recoil';
 
-const Card = ({ tab, location }: CardProps) => {
+const Card = ({ location }: CardProps) => {
   const { userInfo, infoIsLoading } = useGetCardInfo();
+  const tab = useRecoilValue(recoilTabState);
+
   const navigate = useNavigate();
 
   const [openModal, setOpenModal] = useState(false);
@@ -93,7 +97,9 @@ const Card = ({ tab, location }: CardProps) => {
               <ProfileManager page="page" />
             )}
           </UI.StProfileImg>
-          <UI.NavButton onClick={navigateButton}>{buttonText}</UI.NavButton>
+          <UI.NavButton onClick={navigateButton} tab={tab}>
+            {buttonText}
+          </UI.NavButton>
         </UI.RightBlock>
       </UI.StCardBlock>
       {openModal && (

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -72,7 +72,7 @@ const Card = ({ tab, location }: CardProps) => {
         <UI.StInfoBlock>
           <UI.StInfoSpan bolder="bolder" reviseSpan={true}>
             <span>
-              {userInfo.team} : {userInfo.userName}
+              {userInfo.team} &nbsp;|&nbsp; {userInfo.userName}
             </span>
             <BsPencilSquare className="reviseBtn" onClick={onClickCardHandler} />
           </UI.StInfoSpan>

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -108,4 +108,4 @@ const Card = ({ tab, location }: CardProps) => {
   );
 };
 
-export default React.memo(Card);
+export default Card;

--- a/src/components/Card/CardDetail/CardDetail.tsx
+++ b/src/components/Card/CardDetail/CardDetail.tsx
@@ -247,7 +247,9 @@ const CardDetail = ({ closeModal, decodedToken }: CardDetailProps) => {
                 </>
               )}
             </UI.StProfileImg>
-            <UI.JoinDate color="gray">입사일 &nbsp;| &nbsp;{data.joinDay}</UI.JoinDate>
+            {decodedToken.authLevel === 1 ? null : (
+              <UI.JoinDate color="gray">입사일 &nbsp;| &nbsp;{data.joinDay}</UI.JoinDate>
+            )}
           </UI.LeftBlock>
           <UI.StInfoArea>
             <UI.StInfoTitleSpan weight="bolder">

--- a/src/components/Card/CardDetail/style.ts
+++ b/src/components/Card/CardDetail/style.ts
@@ -173,3 +173,11 @@ export const PhoneNumhDot = styled.div<DotProps>`
   right: 7px;
   top: 12px;
 `;
+
+export const ButtonBlock = styled.div`
+  width: 100%;
+
+  margin-top: auto;
+
+  display: flex;
+`;

--- a/src/components/Card/CardDetail/style.ts
+++ b/src/components/Card/CardDetail/style.ts
@@ -57,6 +57,8 @@ export const StInfoTitleSpan = styled.span<FontStyle>`
   font-size: ${({ size }) => (size ? size : '11px')};
   font-weight: ${({ weight }) => (weight ? weight : null)};
   color: ${({ color }) => (color ? 'gray' : null)};
+  width: fit-content;
+  white-space: nowrap;
 `;
 
 export const JoinDate = styled.span`

--- a/src/components/Card/interfaces.ts
+++ b/src/components/Card/interfaces.ts
@@ -1,5 +1,4 @@
 export interface CardProps {
-  tab?: boolean;
   location: 'main' | 'mypage';
 }
 

--- a/src/components/Card/style.ts
+++ b/src/components/Card/style.ts
@@ -107,4 +107,5 @@ export const NavButton = styled.button`
   box-shadow: 0px 4px 4px 0 rgba(152, 185, 223, 1);
   font-size: 10px;
   color: #335985;
+  cursor: pointer;
 `;

--- a/src/components/Card/style.ts
+++ b/src/components/Card/style.ts
@@ -12,16 +12,16 @@ interface TextStyle {
 
 export const StCardBlock = styled.div<CardStyleProps>`
   ${({ tab }) =>
-    tab === false
-      ? css`
-          background-color: ${COLOR.SCHEDULE_BLUE};
-        `
-      : tab === true
+    tab
       ? css`
           background-color: ${COLOR.VACATION_RED};
+          box-shadow: rgba(230, 64, 66, 1) 0px 1px 9px -1px;
+          text-shadow: 0px 1px 4px rgba(230, 64, 66, 1);
         `
       : css`
-          background-color: ${COLOR.PAGE_LIGHTBLUE};
+          background-color: ${COLOR.SCHEDULE_BLUE};
+          box-shadow: rgba(212, 229, 249, 1) 0px 1px 9px -1px;
+          text-shadow: 0px 1px 4px rgba(148, 177, 211, 0.94);
         `};
 
   width: 250px;
@@ -34,9 +34,6 @@ export const StCardBlock = styled.div<CardStyleProps>`
 
   padding: 19px;
   box-sizing: border-box;
-
-  box-shadow: rgba(212, 229, 249, 1) 0px 1px 9px -1px;
-  text-shadow: 0px 1px 4px rgba(148, 177, 211, 0.94);
 `;
 
 export const StInfoBlock = styled.div`
@@ -99,13 +96,22 @@ export const StProfileImg = styled.div`
   }
 `;
 
-export const NavButton = styled.button`
+export const NavButton = styled.button<CardStyleProps>`
+  ${({ tab }) =>
+    tab
+      ? css`
+          box-shadow: rgba(159, 4, 5, 1) 0px 4px 4px 0;
+          color: #8e0608;
+        `
+      : css`
+          box-shadow: rgba(152, 185, 223, 1) 0px 4px 4px 0;
+          color: #335985;
+        `}
   height: 16px;
   background: white;
   border-radius: 3px;
   border: none;
-  box-shadow: 0px 4px 4px 0 rgba(152, 185, 223, 1);
   font-size: 10px;
-  color: #335985;
+
   cursor: pointer;
 `;

--- a/src/components/Feed/Category/CategoryBox.tsx
+++ b/src/components/Feed/Category/CategoryBox.tsx
@@ -15,7 +15,7 @@ import { usePatchFeed } from '../../../api/hooks/Feed/usePatchFeed';
 
 const CategoryBox = ({ categoryId, categoryName, todos }: Category) => {
   const [openTodoInput, setOpenTodoInput] = useState<boolean>(false);
-  const [AddTodoState, setAddTodoHandler, setAddTodoState] = useInput(15);
+  const [AddTodoState, setAddTodoHandler, setAddTodoState] = useInput(20);
   const tab = useRecoilValue(recoilTabState);
   const { mutate } = usePatchFeed();
 

--- a/src/components/Feed/Category/style.ts
+++ b/src/components/Feed/Category/style.ts
@@ -10,7 +10,7 @@ export const StCategoryBlock = styled.div`
   display: flex;
   flex-direction: column;
 
-  gap: 9px;
+  gap: 11px;
   padding-left: 10px;
   box-sizing: border-box;
   margin-bottom: 36px;

--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -60,4 +60,4 @@ const Feed = () => {
   );
 };
 
-export default React.memo(Feed);
+export default Feed;

--- a/src/components/Feed/Todo/AddTodo.tsx
+++ b/src/components/Feed/Todo/AddTodo.tsx
@@ -56,7 +56,6 @@ const AddTodo = ({
       <UI.StTodoInput
         ref={inputRef}
         type="text"
-        maxLength={15}
         value={value}
         onChange={onChange}
         onKeyPress={pressEnterHandle}

--- a/src/components/Feed/Todo/TodoBox.tsx
+++ b/src/components/Feed/Todo/TodoBox.tsx
@@ -7,8 +7,11 @@ import { PatchFeedPayload, Todo } from '../interfaces';
 import { COLOR } from '../../../styles/colors';
 import Swal from 'sweetalert2';
 import { usePatchFeed } from '../../../api/hooks/Feed/usePatchFeed';
+import { useRecoilValue } from 'recoil';
+import { recoilTabState } from '../../../states/recoilTabState';
 
 const TodoBox = ({ todo }: { todo: Todo }) => {
+  const tab = useRecoilValue(recoilTabState);
   const { deleteFeed } = useDeleteFeed();
   const { mutate } = usePatchFeed();
 
@@ -52,12 +55,12 @@ const TodoBox = ({ todo }: { todo: Todo }) => {
   return (
     <UI.StTodoBlock>
       <UI.StTodoAreaBlock>
-        <UI.StCircleBlock isDone={todo.isDone} onClick={clickCircleHandler} />
+        <UI.StCircleBlock isDone={todo.isDone} onClick={clickCircleHandler} tab={tab} />
         <UI.StTodoSpan onClick={ModifyCategory}>{todo.todo}</UI.StTodoSpan>
       </UI.StTodoAreaBlock>
-      <UI.StTestDeleteBlock className="deleteBlock" onClick={deleteBtnHandler}>
+      <UI.StTodoDeleteButton className="deleteBlock" onClick={deleteBtnHandler}>
         <BsX />
-      </UI.StTestDeleteBlock>
+      </UI.StTodoDeleteButton>
     </UI.StTodoBlock>
   );
 };

--- a/src/components/Feed/Todo/style.ts
+++ b/src/components/Feed/Todo/style.ts
@@ -18,7 +18,7 @@ export const StTodoBlock = styled.div`
 
 export const StTodoAreaBlock = styled.div`
   width: fit-content;
-  max-width: 140px;
+  max-width: 180px;
 
   display: flex;
   align-items: center;
@@ -28,13 +28,13 @@ export const StTodoAreaBlock = styled.div`
 `;
 
 export const StTodoSpan = styled.span`
+  width: 150px;
   color: ${COLOR.PAGE_SPAN};
   cursor: pointer;
 `;
 
 export const StTodoInput = styled.input`
-  width: 60%;
-  margin-right: 25%;
+  width: 150px;
   border: none;
   border-radius: 5px;
   font-size: 12px;

--- a/src/components/Feed/Todo/style.ts
+++ b/src/components/Feed/Todo/style.ts
@@ -50,11 +50,15 @@ export const StCircleBlock = styled.div<TodoBoxStProps>`
   height: 12px;
   border-radius: 50%;
   cursor: pointer;
+
+  &:hover {
+    box-shadow: rgba(186, 218, 255, 1) 0 0 7px;
+  }
 `;
 
 export const StTestDeleteBlock = styled.div`
   opacity: 0;
-  font-size: 12px;
+  font-size: 15px;
   color: ${COLOR.PAGE_DONE};
   transition: opacity 0.3s ease;
   &:hover {

--- a/src/components/Feed/Todo/style.ts
+++ b/src/components/Feed/Todo/style.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { COLOR } from '../../../styles/colors';
 interface TodoBoxStProps {
   isDone?: boolean;
+  tab?: boolean;
 }
 
 export const StTodoBlock = styled.div`
@@ -42,9 +43,10 @@ export const StTodoInput = styled.input`
 `;
 
 export const StCircleBlock = styled.div<TodoBoxStProps>`
-  background-color: ${({ isDone }) => (isDone ? COLOR.PAGE_BLUE : 'white')};
+  background-color: ${({ isDone, tab }) =>
+    isDone ? (tab ? COLOR.VACATION_RED : COLOR.PAGE_BLUE) : 'white'};
 
-  border: 1px solid ${({ isDone }) => (isDone ? COLOR.PAGE_BLUE : COLOR.PAGE_LIGHTBLUE)};
+  border: 1px solid ${({ tab }) => (tab ? COLOR.VACATION_RED : COLOR.PAGE_BLUE)};
 
   width: 12px;
   height: 12px;
@@ -56,7 +58,7 @@ export const StCircleBlock = styled.div<TodoBoxStProps>`
   }
 `;
 
-export const StTestDeleteBlock = styled.div`
+export const StTodoDeleteButton = styled.div`
   opacity: 0;
   font-size: 15px;
   color: ${COLOR.PAGE_DONE};

--- a/src/components/RequestList/RequestDetail/RequestDetail.tsx
+++ b/src/components/RequestList/RequestDetail/RequestDetail.tsx
@@ -14,16 +14,16 @@ const RequestDetail = ({ data, isLoading, closeModal, type }: DetailProps) => {
   const { decideRequest } = useDecideRequest();
   const acceptBtnClickHandler = (params: DecideParams) => {
     let message: string;
-    params.types === 'accept' ? (message = '수락') : (message = '거절');
     let icon: SweetAlertIcon;
-    params.types === 'accept' ? (icon = 'success') : (icon = 'error');
+    params.types === 'accept'
+      ? ((message = '수락'), (icon = 'success'))
+      : ((message = '거절'), (icon = 'error'));
     const sweetAlertDiv = document.getElementById('sweetAlertDiv');
     if (!sweetAlertDiv) return;
 
     // alert 창
     Swal.fire({
       title: `${message}하시겠습니까?`,
-      text: "You won't be able to revert this!",
       icon: icon,
       showCancelButton: true,
       confirmButtonColor: 'black',

--- a/src/components/RequestList/RequestDetail/RequestDetail.tsx
+++ b/src/components/RequestList/RequestDetail/RequestDetail.tsx
@@ -26,11 +26,12 @@ const RequestDetail = ({ data, isLoading, closeModal, type }: DetailProps) => {
       text: "You won't be able to revert this!",
       icon: icon,
       showCancelButton: true,
-      confirmButtonColor: COLOR.PAGE_BLUE,
-      cancelButtonColor: COLOR.VACATION_RED,
+      confirmButtonColor: 'black',
+      cancelButtonColor: 'gray',
       confirmButtonText: message,
       cancelButtonText: '닫기',
       target: sweetAlertDiv, // 여기에 target 속성을 추가
+      reverseButtons: true,
       customClass: {
         popup: 'swal-custom-z-index',
       },
@@ -44,7 +45,13 @@ const RequestDetail = ({ data, isLoading, closeModal, type }: DetailProps) => {
       if (result.isConfirmed) {
         closeModal();
         decideRequest(params);
-        Swal.fire(`${message}되었습니다.`, 'success');
+        Swal.fire({
+          position: 'center',
+          icon: 'success',
+          title: `${message}되었습니다.`,
+          showConfirmButton: false,
+          timer: 1000,
+        });
       }
     });
   };

--- a/src/components/VacationTab/Vacation/Vacation.tsx
+++ b/src/components/VacationTab/Vacation/Vacation.tsx
@@ -67,13 +67,11 @@ const Vacation = ({ vacation }: { vacation: VacationList }) => {
   const accept: VacationPayload = {
     status: 'accept',
     Id: vacation.Id,
-    message: '수락',
     userName: vacation.userName,
   };
   const deny: VacationPayload = {
     status: 'deny',
     Id: vacation.Id,
-    message: '거절',
     userName: vacation.userName,
   };
 

--- a/src/components/VacationTab/Vacation/Vacation.tsx
+++ b/src/components/VacationTab/Vacation/Vacation.tsx
@@ -8,6 +8,7 @@ import { BsX } from '@react-icons/all-files/bs/BsX';
 
 import { usePutDecision } from '../../../api/hooks/Vacation/usePutDecision';
 import { VacationList } from '../interfaces';
+import Swal, { SweetAlertIcon } from 'sweetalert2';
 
 const Vacation = ({ vacation }: { vacation: VacationList }) => {
   // 선택창 등장, 퇴장을 위한 state
@@ -78,6 +79,38 @@ const Vacation = ({ vacation }: { vacation: VacationList }) => {
 
   const { mutate } = usePutDecision();
 
+  const decideButton = (decision: string) => {
+    let message: string;
+    let icon: SweetAlertIcon;
+    let decideOpt: Payload;
+    decision === 'accept'
+      ? ((message = '수락'), (icon = 'success'), (decideOpt = accept))
+      : ((message = '거절'), (icon = 'error'), (decideOpt = deny));
+
+    // alert 창
+    Swal.fire({
+      title: `${message}하시겠습니까?`,
+      icon: icon,
+      showCancelButton: true,
+      confirmButtonColor: 'black',
+      cancelButtonColor: 'gray',
+      confirmButtonText: message,
+      cancelButtonText: '닫기',
+      reverseButtons: true,
+    }).then(result => {
+      if (result.isConfirmed) {
+        mutate(decideOpt);
+        Swal.fire({
+          position: 'center',
+          icon: 'success',
+          title: `${message}되었습니다.`,
+          showConfirmButton: false,
+          timer: 1000,
+        });
+      }
+    });
+  };
+
   return (
     <UI.StListBlock onMouseLeave={() => setHover(false)}>
       <UI.StSpanBlock status={vacation.status}>
@@ -91,14 +124,14 @@ const Vacation = ({ vacation }: { vacation: VacationList }) => {
           <UI.StDecAcceptBlock
             className="decision"
             status={true}
-            onClick={() => mutate(deny)}
+            onClick={() => decideButton('deny')}
           >
             <BsX />
           </UI.StDecAcceptBlock>
           <UI.StDecAcceptBlock
             className="decision"
             status={false}
-            onClick={() => mutate(accept)}
+            onClick={() => decideButton('accept')}
           >
             <BsCheck />
           </UI.StDecAcceptBlock>

--- a/src/components/VacationTab/Vacation/Vacation.tsx
+++ b/src/components/VacationTab/Vacation/Vacation.tsx
@@ -7,7 +7,7 @@ import { BsCheck } from '@react-icons/all-files/bs/BsCheck';
 import { BsX } from '@react-icons/all-files/bs/BsX';
 
 import { usePutDecision } from '../../../api/hooks/Vacation/usePutDecision';
-import { VacationList } from '../interfaces';
+import { VacationList, VacationPayload } from '../interfaces';
 import Swal, { SweetAlertIcon } from 'sweetalert2';
 
 const Vacation = ({ vacation }: { vacation: VacationList }) => {
@@ -64,17 +64,17 @@ const Vacation = ({ vacation }: { vacation: VacationList }) => {
   }
 
   // PATCH 요청용 payload
-  interface Payload {
-    status: 'submit' | 'accept' | 'deny';
-    Id: number;
-  }
-  const accept: Payload = {
+  const accept: VacationPayload = {
     status: 'accept',
     Id: vacation.Id,
+    message: '수락',
+    userName: vacation.userName,
   };
-  const deny: Payload = {
+  const deny: VacationPayload = {
     status: 'deny',
     Id: vacation.Id,
+    message: '거절',
+    userName: vacation.userName,
   };
 
   const { mutate } = usePutDecision();
@@ -82,7 +82,7 @@ const Vacation = ({ vacation }: { vacation: VacationList }) => {
   const decideButton = (decision: string) => {
     let message: string;
     let icon: SweetAlertIcon;
-    let decideOpt: Payload;
+    let decideOpt: VacationPayload;
     decision === 'accept'
       ? ((message = '수락'), (icon = 'success'), (decideOpt = accept))
       : ((message = '거절'), (icon = 'error'), (decideOpt = deny));
@@ -100,13 +100,6 @@ const Vacation = ({ vacation }: { vacation: VacationList }) => {
     }).then(result => {
       if (result.isConfirmed) {
         mutate(decideOpt);
-        Swal.fire({
-          position: 'center',
-          icon: 'success',
-          title: `${message}되었습니다.`,
-          showConfirmButton: false,
-          timer: 1000,
-        });
       }
     });
   };

--- a/src/components/VacationTab/interfaces.ts
+++ b/src/components/VacationTab/interfaces.ts
@@ -6,3 +6,10 @@ export interface VacationList {
   end: string;
   status: 'submit' | 'accept' | 'deny';
 }
+
+export interface VacationPayload {
+  status: 'submit' | 'accept' | 'deny';
+  Id: number;
+  message: '수락' | '거절';
+  userName: string;
+}

--- a/src/components/VacationTab/interfaces.ts
+++ b/src/components/VacationTab/interfaces.ts
@@ -10,6 +10,5 @@ export interface VacationList {
 export interface VacationPayload {
   status: 'submit' | 'accept' | 'deny';
   Id: number;
-  message: '수락' | '거절';
   userName: string;
 }

--- a/src/pages/Manager/Manager.tsx
+++ b/src/pages/Manager/Manager.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Tag from '../../components/Tag';
 import Feed from '../../components/Feed';
 import UploadedFileTab from '../../components/UploadedFileTab';
@@ -8,8 +8,14 @@ import VacationTab from '../../components/VacationTab/VacationTab';
 import * as UI from '../MyPage/styles';
 import OneWeekCalendar from '../../components/OneWeekCalendar/OneWeekCalendar';
 import VacationStatus from '../../components/VacationStatus/VacationStatus';
+import { useSetRecoilState } from 'recoil';
+import { recoilTabState } from '../../states/recoilTabState';
 
 const Manager = () => {
+  const setTab = useSetRecoilState(recoilTabState);
+  useEffect(() => {
+    setTab(false);
+  }, []);
   return (
     <UI.Frame>
       <UI.Wrapper>

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Tag from '../../components/Tag';
 import Feed from '../../components/Feed';
 import UploadedFileTab from '../../components/UploadedFileTab';
@@ -7,8 +7,14 @@ import MyRequest from '../../components/MyRequest/MyRequest';
 import * as UI from './styles';
 import OneWeekCalendar from '../../components/OneWeekCalendar/OneWeekCalendar';
 import VacationStatus from '../../components/VacationStatus/VacationStatus';
+import { useSetRecoilState } from 'recoil';
+import { recoilTabState } from '../../states/recoilTabState';
 
 const MyPage = () => {
+  const setTab = useSetRecoilState(recoilTabState);
+  useEffect(() => {
+    setTab(false);
+  }, []);
   return (
     <UI.Frame>
       <UI.Wrapper>

--- a/src/pages/MyPage/styles.ts
+++ b/src/pages/MyPage/styles.ts
@@ -1,8 +1,6 @@
 import styled from 'styled-components';
 
 export const Frame = styled.div`
-  /* width: 1920px;
-  height: 1080px; */
   width: 100%;
   height: 100%;
 

--- a/src/pages/SubMain/Header/Header.tsx
+++ b/src/pages/SubMain/Header/Header.tsx
@@ -89,7 +89,7 @@ function Header(props: HeaderProps) {
 
   return (
     <styles.StWrap>
-      <Card tab={tab} location="main" />
+      <Card location="main" />
       <styles.StContainer tab={tab}>
         <styles.StDateBlock tab={tab}>
           <styles.StYearBlock>


### PR DESCRIPTION
# 유저 피드백, 자체 점검 오류, 패치사항 반영

### todo
- `글자 제한` : 기존 15자가 적다는 의견을 받아들여 20자로 추가하였습니다.

- `완료 체크` : todo 좌측 완료 체크 동그라미에 호버 시 쉐도우를 더해 가시성을 더했습니다.

### 출장, 결제 컨펌
- `UX 개선` : 수락 혹은 거절했을 때 나오는 sweetAlert가 짧은 시간이 지나거나 클릭하면 사라지게 하였습니다.

### 휴가 요청 컨펌
- `UX` : 휴가 요청을 수락 혹은 거절할 때 sweetAlert로 더블체크를 추가했습니다.

- `UX` : 휴가 요청 실패 시 실패 메세지 sweetAlert를 추가했습니다. #233 이슈가 있습니다.

### Card Components
- `에러 수정` : 유효성 체크, 프로필 수정 시 변경사항 체크 부분에서 조건을 추가하여 강화하였습니다.
  - 기존 이미지를 넣으면 생일, 폰번호 유효성 검사를 통과하지 못해도 수정되는 부분 수정

- `리팩토링` : 유효성 체크 메세지 부분을 압축했습니다.

- `UX` : 닫기 버튼이 생기고, 닫기 버튼을 누를 시 수정모드에서 변경중인 사항이 있다면 정말 나갈건지 더블체크 sweetAlert를 적용했습니다.

### React.memo 제거
- `리팩토링` : 기존의 Card와 Feed에 있던 React.memo 가 성능개선에 도움이 안된다는 판단에 제거하였습니다.

### 카드, 피드 테마 로직 개선
- `에러` : 메인페이지에서 테마 변경 후 마이페이지, 매니저페이지로 이동 시 카드의 테마는 초기화되지만 피드의 테마는 남아있는 에러를 수정하였습니다. #234 이슈가 있습니다.