### PR TITLE
마이페이지 로딩스피너 추가

### DIFF
--- a/src/api/hooks/MyRequest/useGetMyRequest.ts
+++ b/src/api/hooks/MyRequest/useGetMyRequest.ts
@@ -10,7 +10,7 @@ export interface PageData {
 }
 
 export const useGetMyRequest = () => {
-  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery<
+  const { data, fetchNextPage, hasNextPage, isLoading } = useInfiniteQuery<
     PageData,
     AxiosError,
     PageData
@@ -35,5 +35,6 @@ export const useGetMyRequest = () => {
     data,
     fetchNextPage: () => fetchNextPage(),
     hasNextPage: hasNextPage || false,
+    isLoading,
   };
 };

--- a/src/api/hooks/Request/useGetRequestDetail.ts
+++ b/src/api/hooks/Request/useGetRequestDetail.ts
@@ -9,18 +9,16 @@ interface Payload {
 }
 
 export const useGetRequestDetail = (payload: Payload) => {
-  const { data, refetch, isLoading } = useQuery<RequestInfo>({
+  const { data, isLoading } = useQuery<RequestInfo>({
     queryKey: [keys.GET_REQUEST_DETAIL, payload.id],
     queryFn: async () => {
       const response = await apis.get(`/${payload.type}/${payload.id}`);
       return response.data;
     },
-    enabled: false,
   });
 
   return {
     data,
-    refetch,
     isLoading,
   };
 };

--- a/src/api/hooks/Tag/useGetTag.ts
+++ b/src/api/hooks/Tag/useGetTag.ts
@@ -10,7 +10,7 @@ export interface PageData {
 }
 
 export const useMentionedSchedules = () => {
-  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery<
+  const { data, fetchNextPage, hasNextPage, isLoading } = useInfiniteQuery<
     PageData,
     AxiosError,
     PageData
@@ -31,5 +31,5 @@ export const useMentionedSchedules = () => {
     },
   });
 
-  return { data, fetchNextPage, hasNextPage: hasNextPage || false };
+  return { data, fetchNextPage, hasNextPage: hasNextPage || false, isLoading };
 };

--- a/src/api/hooks/UploadedFile/useGetFile.ts
+++ b/src/api/hooks/UploadedFile/useGetFile.ts
@@ -9,7 +9,7 @@ export interface PageData {
 }
 
 export const useGetFile = (type: 'myfiles' | 'meetingfiles' | 'reportfiles') => {
-  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery<
+  const { data, fetchNextPage, hasNextPage, isLoading } = useInfiniteQuery<
     PageData,
     AxiosError,
     PageData
@@ -32,5 +32,5 @@ export const useGetFile = (type: 'myfiles' | 'meetingfiles' | 'reportfiles') => 
     },
   });
 
-  return { data, fetchNextPage, hasNextPage: hasNextPage || false };
+  return { data, fetchNextPage, hasNextPage: hasNextPage || false, isLoading };
 };

--- a/src/api/hooks/Vacation/useGetVacation.ts
+++ b/src/api/hooks/Vacation/useGetVacation.ts
@@ -10,7 +10,7 @@ export interface PageData {
 }
 
 export const useGetVacation = () => {
-  const { data, fetchNextPage, hasNextPage } = useInfiniteQuery<
+  const { data, fetchNextPage, hasNextPage, isLoading } = useInfiniteQuery<
     PageData,
     AxiosError,
     PageData
@@ -29,5 +29,5 @@ export const useGetVacation = () => {
     },
   });
 
-  return { data, fetchNextPage, hasNextPage: hasNextPage || false };
+  return { data, fetchNextPage, hasNextPage: hasNextPage || false, isLoading };
 };

--- a/src/api/hooks/Vacation/useGetVacationStatus.ts
+++ b/src/api/hooks/Vacation/useGetVacationStatus.ts
@@ -7,7 +7,7 @@ interface VacationStatus {
 }
 
 export const useGetVacationStatus = () => {
-  const { data } = useQuery<VacationStatus>({
+  const { data, isLoading } = useQuery<VacationStatus>({
     queryKey: [keys.GET_VACATION_STATUS],
     queryFn: async () => {
       const response = await apis.get('/vacationProgress');
@@ -16,5 +16,6 @@ export const useGetVacationStatus = () => {
   });
   return {
     data,
+    isLoading,
   };
 };

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from 'react-router-dom';
 import { BsPencilSquare } from '@react-icons/all-files/bs/BsPencilSquare';
 import { recoilTabState } from '../../states/recoilTabState';
 import { useRecoilValue } from 'recoil';
+import Loading from '../Loading/Loading';
 
 const Card = ({ location }: CardProps) => {
   const { userInfo, infoIsLoading } = useGetCardInfo();
@@ -25,7 +26,11 @@ const Card = ({ location }: CardProps) => {
   const decodedToken: DecodedToken = jwtDecode(token);
 
   if (infoIsLoading || !userInfo) {
-    return <h1>...loading</h1>;
+    return (
+      <UI.LoadingBlock>
+        <Loading />
+      </UI.LoadingBlock>
+    );
   }
 
   // 카드 클릭 시 Detail 요청, Modal open

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -57,7 +57,7 @@ const Card = ({ location }: CardProps) => {
           navigate('/manager');
         };
       } else {
-        buttonText = `유저 생성 >`;
+        buttonText = `유저 관리 >`;
         navigateButton = e => {
           e.stopPropagation();
           navigate('/business');

--- a/src/components/Card/style.ts
+++ b/src/components/Card/style.ts
@@ -116,3 +116,12 @@ export const NavButton = styled.button<CardStyleProps>`
 
   cursor: pointer;
 `;
+
+export const LoadingBlock = styled.div`
+  width: 250px;
+  height: 116px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/src/components/Feed/Feed.tsx
+++ b/src/components/Feed/Feed.tsx
@@ -6,6 +6,7 @@ import FeedTitle from './FeedTitle';
 import { useGetFeed } from '../../api/hooks/Feed/useGetFeed';
 import { Category } from './interfaces';
 import useInput from '../../hooks/common/useInput';
+import Loading from '../Loading/Loading';
 
 const Feed = () => {
   const [openCategoryInput, setOpenCategoryInput] = useState<boolean>(false);
@@ -30,7 +31,11 @@ const Feed = () => {
   const { feed, feedIsLoading } = useGetFeed();
 
   if (feedIsLoading && !feed) {
-    return <div>Loading...</div>;
+    return (
+      <UI.LoadingBlock>
+        <Loading />
+      </UI.LoadingBlock>
+    );
   }
 
   return (

--- a/src/components/Feed/style.ts
+++ b/src/components/Feed/style.ts
@@ -74,9 +74,10 @@ export const StFeedTitleH1 = styled.h1<TitleProps>`
 `;
 
 export const LoadingBlock = styled.div`
-  width: 250px;
-  height: 635px;
+  width: 100%;
+  height: 100%;
 
   display: flex;
   justify-content: center;
+  align-items: center;
 `;

--- a/src/components/Feed/style.ts
+++ b/src/components/Feed/style.ts
@@ -72,3 +72,11 @@ export const StFeedTitleH1 = styled.h1<TitleProps>`
           color: ${COLOR.VACATION_RED};
         `};
 `;
+
+export const LoadingBlock = styled.div`
+  width: 250px;
+  height: 635px;
+
+  display: flex;
+  justify-content: center;
+`;

--- a/src/components/Main/CustomCalendar/CustomCalendar.tsx
+++ b/src/components/Main/CustomCalendar/CustomCalendar.tsx
@@ -8,11 +8,13 @@ import {
   StLine,
   StEventBlock,
   StEventContainer,
+  LoadingBlock,
 } from './styles';
 import Weekday from './Weekday';
 import useGetWeeklyInfo from '../../../api/hooks/Weekly/useGetWeeklyInfo';
 import { is } from 'cheerio/lib/api/traversing';
 import { getScheduleColor } from '../../../pages/SubMain/utils';
+import Loading from '../../Loading/Loading';
 
 interface CalendarProps {
   width: string;
@@ -162,6 +164,14 @@ const CustomCalendar = (props: CalendarProps) => {
 
     return resultArr;
   }, [selectedYear, selectedMonth, events]);
+
+  if (isLoading) {
+    return (
+      <LoadingBlock>
+        <Loading />
+      </LoadingBlock>
+    );
+  }
 
   return (
     <StContainer width={width} onClick={props.onClick}>

--- a/src/components/Main/CustomCalendar/styles.ts
+++ b/src/components/Main/CustomCalendar/styles.ts
@@ -22,6 +22,14 @@ const StContainer = styled.div<CalendarProps>`
   cursor: pointer;
 `;
 
+const LoadingBlock = styled.div`
+  width: 910px;
+  height: 116px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 const StWeekBlock = styled.div`
   display: flex;
   padding-bottom: 5px;
@@ -76,4 +84,5 @@ export {
   StLine,
   StEventBlock,
   StEventContainer,
+  LoadingBlock,
 };

--- a/src/components/MyRequest/MyRequest.tsx
+++ b/src/components/MyRequest/MyRequest.tsx
@@ -5,9 +5,12 @@ import Board from '../Board';
 import BusinessIcon from '../../assets/Icons/BusinessIcon';
 import { COLOR } from '../../styles/colors';
 import { useInfiniteQueryHook } from '../../hooks/common/useInfiniteQueryHook';
+import { LoadingBlock } from './MyRequestList/style';
+import Loading from '../Loading/Loading';
+import { MyListProps } from './interfaces';
 
 const MyRequest = () => {
-  const { data, fetchNextPage, hasNextPage } = useGetMyRequest();
+  const { data, fetchNextPage, hasNextPage, isLoading } = useGetMyRequest();
 
   // 무한스크롤을 적용할 div를 타겟하기 위해 추가한 useRef
   const targetDiv = useRef<HTMLDivElement | null>(null);
@@ -21,11 +24,21 @@ const MyRequest = () => {
   // Board title에 들어갈 icon
   const icon = <BusinessIcon width="21px" height="15px" fill={COLOR.PAGE_BLUE} />;
 
+  const NoData = files.length === 0;
+
   return (
     <Board icon={icon} title="내가 올린 결재" targetDiv={targetDiv}>
-      {files.map(file => {
-        return <MyRequestList key={file.Id} file={file} />;
-      })}
+      {isLoading ? (
+        <LoadingBlock>
+          <Loading />
+        </LoadingBlock>
+      ) : NoData ? (
+        <LoadingBlock>요청한 결재가 없습니다.</LoadingBlock>
+      ) : (
+        files.map(file => {
+          return <MyRequestList key={file.Id} file={file} />;
+        })
+      )}
     </Board>
   );
 };

--- a/src/components/MyRequest/MyRequestList/style.ts
+++ b/src/components/MyRequest/MyRequestList/style.ts
@@ -24,6 +24,15 @@ export const StFileBlock = styled.div<StatusProps>`
   }
 `;
 
+export const LoadingBlock = styled.div`
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 export const StSpanBlock = styled.div`
   width: 100%;
 

--- a/src/components/RequestList/Request.tsx
+++ b/src/components/RequestList/Request.tsx
@@ -6,6 +6,8 @@ import { RequestType } from './interfaces';
 import BusinessIcon from '../../assets/Icons/BusinessIcon';
 import { COLOR } from '../../styles/colors';
 import { useInfiniteQueryHook } from '../../hooks/common/useInfiniteQueryHook';
+import { LoadingBlock } from './RequestedOne/style';
+import Loading from '../Loading/Loading';
 
 const Request = ({ type }: RequestType) => {
   const { data, fetchNextPage, hasNextPage, isLoading } = useGetRequest(type);
@@ -27,24 +29,29 @@ const Request = ({ type }: RequestType) => {
   // Board title에 들어갈 icon
   const icon = <BusinessIcon width="21px" height="15px" fill={COLOR.PAGE_LIGHTBLUE} />;
 
-  if (isLoading) {
-    return (
-      <Board icon={icon} title={title} targetDiv={targetDiv}>
-        ...loading
-      </Board>
-    );
-  }
-
   // data.pages를 풀어서 하나의 배열로 -> useInfiniteQuery 에서 return 하는 data 형식 참고.
   const requests = data
     ? data.pages.flatMap(page => ('schedule' in page ? page.schedule : page.other))
     : [];
 
+  const NoData = requests.length === 0;
+
+  let NoDataMessage;
+  type === 'schedule' ? (NoDataMessage = '출장이') : (NoDataMessage = '결재가');
+
   return (
     <Board icon={icon} title={title} targetDiv={targetDiv}>
-      {requests.map(request => {
-        return <RequestedOne key={request.Id} request={request} type={type} />;
-      })}
+      {isLoading ? (
+        <LoadingBlock>
+          <Loading />
+        </LoadingBlock>
+      ) : NoData ? (
+        <LoadingBlock>{`요청된 ${NoDataMessage} 없습니다.`}</LoadingBlock>
+      ) : (
+        requests.map(request => {
+          return <RequestedOne key={request.Id} request={request} type={type} />;
+        })
+      )}
     </Board>
   );
 };

--- a/src/components/RequestList/RequestDetail/RequestDetail.tsx
+++ b/src/components/RequestList/RequestDetail/RequestDetail.tsx
@@ -3,12 +3,27 @@ import * as UI from './style';
 import { DecideParams, DetailProps } from '../interfaces';
 import { useDecideRequest } from '../../../api/hooks/Request/useDecideRequest';
 import Swal, { SweetAlertIcon } from 'sweetalert2';
+import { useGetRequestDetail } from '../../../api/hooks/Request/useGetRequestDetail';
+import Loading from '../../Loading/Loading';
 
-const RequestDetail = ({ data, isLoading, closeModal, type }: DetailProps) => {
+const RequestDetail = ({ eventId, closeModal, type }: DetailProps) => {
+  const detailPayload = {
+    type: type,
+    id: eventId,
+  };
+
+  const { data, isLoading } = useGetRequestDetail(detailPayload);
+
   const { decideRequest } = useDecideRequest();
 
   if (isLoading || !data) {
-    return <div>Loading....</div>;
+    return (
+      <UI.Modal>
+        <UI.LoadingBlock>
+          <Loading />
+        </UI.LoadingBlock>
+      </UI.Modal>
+    );
   }
 
   // 수락 거절 버튼 핸들러

--- a/src/components/RequestList/RequestDetail/style.ts
+++ b/src/components/RequestList/RequestDetail/style.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { COLOR } from '../../../styles/colors';
 
 interface DeviderProps {
   positions: 'Header' | 'Footer';
@@ -15,6 +14,14 @@ export const Modal = styled.div`
 
   display: flex;
   flex-direction: column;
+`;
+
+export const LoadingBlock = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 export const Header = styled.div`

--- a/src/components/RequestList/RequestedOne/RequestedOne.tsx
+++ b/src/components/RequestList/RequestedOne/RequestedOne.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import * as UI from './style';
-import { useGetRequestDetail } from '../../../api/hooks/Request/useGetRequestDetail';
 import Modal from '../../Atoms/Modal/CustomModal';
 import RequestDetail from '../RequestDetail';
 import Person from '../../../assets/Icons/Person';
@@ -9,19 +8,11 @@ import { RequestedOneProps } from '../interfaces';
 
 const RequestedOne = ({ request, type }: RequestedOneProps) => {
   // GETdetail payload
-  const detailPayload = {
-    type: type,
-    id: request.Id,
-  };
 
-  const { data, refetch, isLoading } = useGetRequestDetail(detailPayload);
   const [modalOpen, setModalOpen] = useState(false);
-
-  if (isLoading) <div>Loading...</div>;
 
   // 모달을 띄우고, GETdetail 요청을 보내서 모달에 전달.
   const getDetail = () => {
-    refetch();
     setModalOpen(true);
   };
   const closeModal = () => {
@@ -53,12 +44,7 @@ const RequestedOne = ({ request, type }: RequestedOneProps) => {
       </UI.StRequestedListBlock>
       {modalOpen && (
         <Modal closeModal={closeModal}>
-          <RequestDetail
-            data={data}
-            isLoading={isLoading}
-            closeModal={closeModal}
-            type={type}
-          />
+          <RequestDetail closeModal={closeModal} type={type} eventId={request.Id} />
         </Modal>
       )}
     </>

--- a/src/components/RequestList/RequestedOne/style.ts
+++ b/src/components/RequestList/RequestedOne/style.ts
@@ -23,6 +23,14 @@ export const StRequestedListBlock = styled.div<RequestStatus>`
   }
 `;
 
+export const LoadingBlock = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 export const StNameDateDiv = styled.div`
   width: 100%;
   display: flex;

--- a/src/components/RequestList/interfaces.ts
+++ b/src/components/RequestList/interfaces.ts
@@ -18,8 +18,7 @@ export interface RequestInfo {
   userName: string;
 }
 export interface DetailProps {
-  data: RequestInfo | undefined;
-  isLoading: boolean;
+  eventId: number;
   closeModal: () => void;
   type: 'schedule' | 'other';
 }

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -6,10 +6,12 @@ import { TagBlockCssProps } from './interfaces';
 import Board from '../Board';
 import TagIconTitle from '../../assets/Icons/TagIconTitle';
 import { useInfiniteQueryHook } from '../../hooks/common/useInfiniteQueryHook';
+import Loading from '../Loading/Loading';
+import { LoadingBlock } from './Tags/style';
 
 const Tag = ({ types }: TagBlockCssProps) => {
   // 무한스크롤 코드
-  const { data, fetchNextPage, hasNextPage } = useMentionedSchedules();
+  const { data, fetchNextPage, hasNextPage, isLoading } = useMentionedSchedules();
 
   // 무한스크롤을 적용할 div를 타겟하기 위해 추가한 useRef
   const targetDiv = useRef<HTMLDivElement | null>(null);
@@ -25,9 +27,15 @@ const Tag = ({ types }: TagBlockCssProps) => {
 
   return (
     <Board icon={icon} title="tag" types={types} targetDiv={targetDiv}>
-      {tags.map((tag: Mention) => {
-        return <Tags key={tag.mentionId} tag={tag} types={types} />;
-      })}
+      {isLoading ? (
+        <LoadingBlock>
+          <Loading />
+        </LoadingBlock>
+      ) : (
+        tags.map((tag: Mention) => {
+          return <Tags key={tag.mentionId} tag={tag} types={types} />;
+        })
+      )}
     </Board>
   );
 };

--- a/src/components/Tag/Tags/style.ts
+++ b/src/components/Tag/Tags/style.ts
@@ -22,6 +22,15 @@ export const StTagsBlock = styled.div<BlockProps>`
   font-weight: ${({ isChecked }) => (isChecked ? 'lighter' : 'bold')};
 `;
 
+export const LoadingBlock = styled.div`
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 export const StContentSpan = styled.span<SpanProps>`
   font-size: ${({ types }) => (types === 'MyPage' ? '15px' : '14px')};
 

--- a/src/components/UploadedFileTab/UploadedDetail/UploadedDetail.tsx
+++ b/src/components/UploadedFileTab/UploadedDetail/UploadedDetail.tsx
@@ -1,6 +1,7 @@
 import * as UI from './style';
 import { DetailProps } from '../interfaces';
 import { useGetUploadedDetail } from '../../../api/hooks/UploadedFile/useGetUploadedDetail';
+import Loading from '../../Loading/Loading';
 
 const UploadedDetail = ({ eventId, types, closeModal }: DetailProps) => {
   const payload = {
@@ -10,7 +11,13 @@ const UploadedDetail = ({ eventId, types, closeModal }: DetailProps) => {
 
   const { data, isLoading } = useGetUploadedDetail(payload);
   if (isLoading || !data) {
-    return <div>Loading....</div>;
+    return (
+      <UI.Modal>
+        <UI.LoadingBlock>
+          <Loading />
+        </UI.LoadingBlock>
+      </UI.Modal>
+    );
   }
 
   let files;

--- a/src/components/UploadedFileTab/UploadedDetail/style.ts
+++ b/src/components/UploadedFileTab/UploadedDetail/style.ts
@@ -15,6 +15,14 @@ export const Modal = styled.div`
   box-shadow: rgba(15, 19, 24, 0.27) 0 4px 30px 8px;
 `;
 
+export const LoadingBlock = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 export const Header = styled.div`
   /* background-color: yellow; */
   width: 100%;

--- a/src/components/UploadedFileTab/UploadedFileTab.tsx
+++ b/src/components/UploadedFileTab/UploadedFileTab.tsx
@@ -7,9 +7,11 @@ import FolderIcon from '../../assets/Icons/FolderIcon';
 import BusinessIcon from '../../assets/Icons/BusinessIcon';
 import { COLOR } from '../../styles/colors';
 import { useInfiniteQueryHook } from '../../hooks/common/useInfiniteQueryHook';
+import { LoadingBlock } from './UploadedOne/style';
+import Loading from '../Loading/Loading';
 
 const UploadedFileTab = ({ type }: UploadedFileTabProps) => {
-  const { data, fetchNextPage, hasNextPage } = useGetFile(type);
+  const { data, fetchNextPage, hasNextPage, isLoading } = useGetFile(type);
 
   // 무한스크롤을 적용할 div를 타겟하기 위해 추가한 useRef
   const targetDiv = useRef<HTMLDivElement | null>(null);
@@ -24,7 +26,7 @@ const UploadedFileTab = ({ type }: UploadedFileTabProps) => {
   let title;
   let icon;
   switch (type) {
-    case 'meetingfiles' || 'reportfiles': {
+    case 'meetingfiles': {
       title = '회의록';
       icon = <FolderIcon width="21px" height="15px" fill={COLOR.PAGE_LIGHTBLUE} />;
       break;
@@ -41,11 +43,24 @@ const UploadedFileTab = ({ type }: UploadedFileTabProps) => {
     }
   }
 
+  // 받아온 데이터가 없을 시 NoData는 true.
+  const NoData = files.length === 0;
+
   return (
     <Board icon={icon} title={title} targetDiv={targetDiv}>
-      {files.map((file: UploadedFileList) => {
-        return <UploadedOne key={file.Id} file={file} type={type} />;
-      })}
+      {isLoading ? (
+        <LoadingBlock>
+          <Loading />
+        </LoadingBlock>
+      ) : NoData ? (
+        <LoadingBlock>
+          게시된 {type === 'reportfiles' ? `${title}가` : `${title}이`} 없습니다.
+        </LoadingBlock>
+      ) : (
+        files.map((file: UploadedFileList) => {
+          return <UploadedOne key={file.Id} file={file} type={type} />;
+        })
+      )}
     </Board>
   );
 };

--- a/src/components/UploadedFileTab/UploadedOne/style.ts
+++ b/src/components/UploadedFileTab/UploadedOne/style.ts
@@ -21,6 +21,14 @@ export const StUploadedFileBlock = styled.div`
   }
 `;
 
+export const LoadingBlock = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 export const StNameDateBlock = styled.div`
   width: 100%;
   display: flex;

--- a/src/components/VacationStatus/VacationStatus.tsx
+++ b/src/components/VacationStatus/VacationStatus.tsx
@@ -4,9 +4,18 @@ import { useGetVacationStatus } from '../../api/hooks/Vacation/useGetVacationSta
 import WorkingMeerkat from '../../assets/Meerkat/WorkingMeerkat';
 import VacationMeerkat from '../../assets/Meerkat/VacationMeerkat';
 import WaitingVacation from '../../assets/Meerkat/WaitingVacation';
+import Loading from '../Loading/Loading';
 
 const VacationStatus = () => {
-  const { data } = useGetVacationStatus();
+  const { data, isLoading } = useGetVacationStatus();
+
+  if (isLoading || !data) {
+    return (
+      <UI.LoadingBlock>
+        <Loading />
+      </UI.LoadingBlock>
+    );
+  }
 
   let svgFile;
   if (data) {

--- a/src/components/VacationStatus/style.ts
+++ b/src/components/VacationStatus/style.ts
@@ -6,3 +6,13 @@ export const SvgBlock = styled.div`
 
   box-shadow: rgba(236, 241, 248, 1) 4px 0 9px 0;
 `;
+
+export const LoadingBlock = styled.div`
+  width: 250px;
+  height: 85px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: rgba(236, 241, 248, 1) 4px 0 9px 0;
+`;

--- a/src/components/VacationTab/Vacation/style.ts
+++ b/src/components/VacationTab/Vacation/style.ts
@@ -23,6 +23,14 @@ export const StListBlock = styled.div`
   margin-bottom: 11px;
 `;
 
+export const LoadingBlock = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 export const StSpanBlock = styled.div<SpanProps>`
   width: 65%;
   height: 100%;

--- a/src/components/VacationTab/VacationTab.tsx
+++ b/src/components/VacationTab/VacationTab.tsx
@@ -5,10 +5,12 @@ import { VacationList } from './interfaces';
 import Board from '../Board';
 import CalendarIcon from '../../assets/Icons/CalendarIcon';
 import { useInfiniteQueryHook } from '../../hooks/common/useInfiniteQueryHook';
+import { LoadingBlock } from './Vacation/style';
+import Loading from '../Loading/Loading';
 
 const VacationTab = () => {
   // Vacation 리스트 GET 요청
-  const { data, fetchNextPage, hasNextPage } = useGetVacation();
+  const { data, fetchNextPage, hasNextPage, isLoading } = useGetVacation();
 
   // 무한스크롤을 적용할 div를 타겟하기 위해 추가한 useRef
   const targetDiv = useRef<HTMLDivElement | null>(null);
@@ -19,18 +21,24 @@ const VacationTab = () => {
   // data.pages를 풀어서 하나의 배열로 -> useInfiniteQuery 에서 return 하는 data 형식 참고.
   const vacations = data ? data.pages.flatMap(page => page.vacation) : [];
 
-  if (!vacations) {
-    return <h1>....loading</h1>;
-  }
-
   // Board title에 들어갈 icon
   const icon = <CalendarIcon usage="title" />;
 
+  const NoData = vacations.length === 0;
+
   return (
     <Board icon={icon} title="휴가 요청" targetDiv={targetDiv}>
-      {vacations?.map((vacation: VacationList) => {
-        return <Vacation key={vacation.Id} vacation={vacation} />;
-      })}
+      {isLoading ? (
+        <LoadingBlock>
+          <Loading />
+        </LoadingBlock>
+      ) : NoData ? (
+        <LoadingBlock>요청된 휴가가 없습니다.</LoadingBlock>
+      ) : (
+        vacations?.map((vacation: VacationList) => {
+          return <Vacation key={vacation.Id} vacation={vacation} />;
+        })
+      )}
     </Board>
   );
 };


### PR DESCRIPTION
# 마이페이지에서 사용하는 모든 컴포넌트들에 로딩스피너가 추가되었습니다.

### 컴포넌트마다 `LoadingBlock` 이라는 `styled-component`로 만든 `div`태그가 생겼지만 추후 통합예정입니다.

### 그 외 매니저페이지의 요청 디테일 GET 으로 정보를 가져오는 부분에서 수정이 있었습니다.
- 기존 GET요청에 `enabled: false`를 주고 상위 컴포넌트에서 호출 뒤 디테일 모달을 열며 `refetch`를 하고 디테일 컴포넌트로 데이터를 프롭스로 넘겨주는 방식 -> GET요청에서 `enabled: false`와 `refetch`를 삭제하고 디테일 컴포넌트에서 직접 요청을 보내는 방식으로 수정하였습니다.