### PR TITLE
[FEAT] : ⚙️  Error Message 구조분해 할당 받기

### DIFF
--- a/src/api/axios/api.tsx
+++ b/src/api/axios/api.tsx
@@ -1,8 +1,21 @@
-import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { getCookie } from '../auth/CookieUtils';
-
 const config: AxiosRequestConfig = {
   baseURL: process.env.REACT_APP_SERVER,
+};
+
+export interface ConvertError {
+  status: number;
+  message: string;
+  data: any;
+}
+
+const convertErrorResponse = (response: AxiosResponse): ConvertError => {
+  return {
+    status: response.status ?? 500,
+    message: response.data.errorMessage ?? '알 수 없는 에러가 발생했습니다.',
+    data: response.data,
+  };
 };
 
 const apis: AxiosInstance = axios.create(config);
@@ -29,7 +42,8 @@ apis.interceptors.response.use(
 
   // 오류 응답을 내보내기 전 수행되는 함수
   function (error) {
-    return Promise.reject(error);
+    console.log(error.response);
+    return Promise.reject(convertErrorResponse(error.response));
   }
 );
 

--- a/src/api/hooks/Vacation/usePutDecision.ts
+++ b/src/api/hooks/Vacation/usePutDecision.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import apis from '../../axios/api';
+import apis, { ConvertError } from '../../axios/api';
 import { keys } from '../../utils/createQueryKey';
 import Swal, { SweetAlertIcon } from 'sweetalert2';
 import { AxiosError } from 'axios';
@@ -48,10 +48,10 @@ export const usePutDecision = () => {
     },
 
     // 요청 실패 시
-    onError: (error: AxiosError<ErrorData>, payload) => {
+    onError: (error: ConvertError, payload) => {
       // 에러메세지 세팅
-      if (error.response?.data.errorMessage === '남은 연차 일수가 부족합니다.') {
-        const errorMessage = `<div style="font-size: 20px;">${payload.userName}님의 ${error.response?.data.errorMessage}</div> <div style="font-size: 20px;">휴가가 자동으로 반려됩니다.</div>`;
+      if (error.message === '남은 연차 일수가 부족합니다.') {
+        const errorMessage = `<div style="font-size: 20px;">${payload.userName}님의 ${error.message}</div> <div style="font-size: 20px;">휴가가 자동으로 반려됩니다.</div>`;
 
         const errorDeny: VacationPayload = {
           status: 'deny',
@@ -70,7 +70,7 @@ export const usePutDecision = () => {
           mutate(errorDeny);
         });
       } else if (!shouldSkipErrorAlert.current) {
-        const errorMessage = error.response?.data.errorMessage;
+        const errorMessage = error.message;
         // 요청 실패 알럿
         Swal.fire({
           position: 'center',

--- a/src/components/Main/DocumentForm/ScheduleFormat/ScheduleFormat.tsx
+++ b/src/components/Main/DocumentForm/ScheduleFormat/ScheduleFormat.tsx
@@ -5,7 +5,7 @@ import usePostschedule from '../../../../api/hooks/Main/usePostschedule';
 import useMoveScroll from '../../../../api/hooks/Main/useMoveScroll';
 import { recoilTabState } from '../../../../states/recoilTabState';
 import useTextarea from '../../../../hooks/common/useTextarea';
-import { ErrorData, ScheduleProps } from '../commonInterface';
+import { ScheduleProps } from '../commonInterface';
 import CustomButton from '../../../Atoms/Button/CustomButton';
 import { getCookie } from '../../../../api/auth/CookieUtils';
 import FileUpload from '../components/FileUpload/FileUpload';
@@ -17,8 +17,7 @@ import Period from '../components/Period/Period';
 import 'react-toastify/dist/ReactToastify.css';
 import * as UI from '../commonStyles';
 import { useRecoilValue } from 'recoil';
-import { AxiosError } from 'axios';
-import Swal from 'sweetalert2';
+import Swal, { SweetAlertResult } from 'sweetalert2';
 import ReportModal from '../../Modal/ReportModal/ReportModal';
 import CustomModal from '../../../Atoms/Modal/CustomModal';
 
@@ -77,7 +76,7 @@ const ScheduleFormat = ({
         confirmButtonText: '네,추가하겠습니다!',
         cancelButtonText: '아니요, 취소할게요!',
         reverseButtons: true,
-      }).then(result => {
+      }).then((result: SweetAlertResult) => {
         if (result.isConfirmed) {
           const newProps = {
             ...props,
@@ -104,10 +103,8 @@ const ScheduleFormat = ({
                 theme: 'light',
               });
             },
-            onError: error => {
-              const errorData: AxiosError = error as AxiosError;
-              const errorOjbect: ErrorData = errorData.response?.data as ErrorData;
-              toast.error(`❌ ${errorOjbect.errorMessage}`, {
+            onError: (error: any) => {
+              toast.error(`❌ ${error.message}`, {
                 position: 'top-right',
                 autoClose: 2000,
                 hideProgressBar: false,
@@ -148,7 +145,7 @@ const ScheduleFormat = ({
           confirmButtonText: '네,취소하겠습니다!',
           cancelButtonText: '아니요, 작성할게요!',
           reverseButtons: true,
-        }).then(result => {
+        }).then((result: SweetAlertResult) => {
           if (result.isConfirmed) {
             setCreateShedule(false);
             Swal.fire('취소되었습니다!', '해당 일정이 삭제되었습니다.', 'success');
@@ -173,7 +170,7 @@ const ScheduleFormat = ({
       confirmButtonText: '네,취소하겠습니다!',
       cancelButtonText: '아니요, 작성할게요!',
       reverseButtons: true,
-    }).then(result => {
+    }).then((result: SweetAlertResult) => {
       if (result.isConfirmed) {
         setCreateShedule(false);
         Swal.fire('취소되었습니다!', '해당 일정이 삭제되었습니다.', 'success');
@@ -198,7 +195,7 @@ const ScheduleFormat = ({
       confirmButtonText: '네,취소하겠습니다!',
       cancelButtonText: '아니요, 작성할게요!',
       reverseButtons: true,
-    }).then(result => {
+    }).then((result: SweetAlertResult) => {
       if (result.isConfirmed) {
         setCreateShedule(false);
         Swal.fire('취소되었습니다!', '해당 일정이 삭제되었습니다.', 'success');

--- a/src/components/Main/DocumentForm/VacationFormat/VacationFormat.tsx
+++ b/src/components/Main/DocumentForm/VacationFormat/VacationFormat.tsx
@@ -6,10 +6,9 @@ import useTextarea from '../../../../hooks/common/useTextarea';
 import Period from '../components/Period/Period';
 import { RiArrowLeftSLine } from '@react-icons/all-files/ri/RiArrowLeftSLine';
 import { ToastContainer, toast } from 'react-toastify';
-import { AxiosError } from 'axios';
 import usePostVacation from '../../../../api/hooks/Main/usePostVacation';
-import { ErrorData, ScheduleProps } from '../commonInterface';
-import Swal from 'sweetalert2';
+import { ScheduleProps } from '../commonInterface';
+import Swal, { SweetAlertResult } from 'sweetalert2';
 import CustomButton from '../../../Atoms/Button/CustomButton';
 import useMoveScroll from '../../../../api/hooks/Main/useMoveScroll';
 import { recoilTabState } from '../../../../states/recoilTabState';
@@ -37,7 +36,7 @@ const VacationFormat = ({
         confirmButtonText: '네,추가하겠습니다!',
         cancelButtonText: '아니요, 취소할게요!',
         reverseButtons: true,
-      }).then(result => {
+      }).then((result: SweetAlertResult) => {
         if (result.isConfirmed) {
           const newProps = {
             ...props,
@@ -63,10 +62,8 @@ const VacationFormat = ({
                 theme: 'light',
               });
             },
-            onError: error => {
-              const errorData: AxiosError = error as AxiosError;
-              const errorOjbect: ErrorData = errorData.response?.data as ErrorData;
-              toast.error(`❌ ${errorOjbect.errorMessage}`, {
+            onError: (error: any) => {
+              toast.error(`❌ ${error.message}`, {
                 position: 'top-right',
                 autoClose: 2000,
                 hideProgressBar: false,
@@ -120,7 +117,7 @@ const VacationFormat = ({
           confirmButtonText: '네,취소하겠습니다!',
           cancelButtonText: '아니요, 작성할게요!',
           reverseButtons: true,
-        }).then(result => {
+        }).then((result: SweetAlertResult) => {
           if (result.isConfirmed) {
             Swal.fire('취소되었습니다!', '해당 일정이 삭제되었습니다.', 'success');
             onCancelHandler(props.id, props.calendarId);
@@ -144,7 +141,7 @@ const VacationFormat = ({
       confirmButtonText: '네,취소하겠습니다!',
       cancelButtonText: '아니요, 작성할게요!',
       reverseButtons: true,
-    }).then(result => {
+    }).then((result: SweetAlertResult) => {
       if (result.isConfirmed) {
         Swal.fire('취소되었습니다!', '해당 일정이 삭제되었습니다.', 'success');
         onCancelHandler(props.id, props.calendarId);

--- a/src/components/Main/Modal/ReportModal/ReportModal.tsx
+++ b/src/components/Main/Modal/ReportModal/ReportModal.tsx
@@ -15,8 +15,9 @@ import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRecoilValue } from 'recoil';
 import { AxiosError } from 'axios';
-import Swal from 'sweetalert2';
+import Swal, { SweetAlertResult } from 'sweetalert2';
 import * as UI from './styles';
+import { ConvertError } from '../../../../api/axios/api';
 
 const ReportModal = ({ value, setOpen }: ReportModalProps) => {
   const { register, handleSubmit, reset } = useForm<ReportInfo>();
@@ -36,9 +37,8 @@ const ReportModal = ({ value, setOpen }: ReportModalProps) => {
     setOpen(false);
   };
 
-  const errorHandler = (error: AxiosError) => {
-    const errorOjbect: ErrorData = error.response?.data as ErrorData;
-    setErrorMessage(errorOjbect.errorMessage);
+  const errorHandler = (error: ConvertError) => {
+    setErrorMessage(error.message);
     setSuccess(1);
   };
 
@@ -87,7 +87,7 @@ const ReportModal = ({ value, setOpen }: ReportModalProps) => {
       confirmButtonText: '네,추가하겠습니다!',
       cancelButtonText: '아니요, 취소할게요!',
       reverseButtons: true,
-    }).then(result => {
+    }).then((result: SweetAlertResult) => {
       if (result.isConfirmed) {
         const payload = {
           title: item.title,
@@ -104,9 +104,8 @@ const ReportModal = ({ value, setOpen }: ReportModalProps) => {
               onSuccess: () => {
                 successHandler();
               },
-              onError: error => {
-                const errorData: AxiosError = error as AxiosError;
-                errorHandler(errorData);
+              onError: (error: any) => {
+                errorHandler(error);
               },
             });
             break;
@@ -122,9 +121,8 @@ const ReportModal = ({ value, setOpen }: ReportModalProps) => {
                 onSuccess: () => {
                   successHandler();
                 },
-                onError: error => {
-                  const errorData: AxiosError = error as AxiosError;
-                  errorHandler(errorData);
+                onError: (error: any) => {
+                  errorHandler(error);
                 },
               });
             }
@@ -135,9 +133,8 @@ const ReportModal = ({ value, setOpen }: ReportModalProps) => {
               onSuccess: () => {
                 successHandler();
               },
-              onError: error => {
-                const errorData: AxiosError = error as AxiosError;
-                errorHandler(errorData);
+              onError: (error: any) => {
+                errorHandler(error);
               },
             });
             break;


### PR DESCRIPTION
## 인터셉터 Error 리턴 시, 필요한 데이터만 구조분해 할당으로 전달 

## 문제  

```tsx
onError: (error: AxiosError<ErrorData>, payload) => {
      // 에러메세지 세팅
      if (error.response?.data.errorMessage === '남은 연차 일수가 부족합니다.') {
        const errorMessage = `<div style="font-size: 20px;">${payload.userName}님의 ${error.response?.data.errorMessage}</div> <div style="font-size: 20px;">휴가가 자동으로 반려됩니다.</div>`;
```

```tsx
onError: (error: AxiosError<ErrorData>, payload) => {
      // 에러메세지 세팅
      if (error.response?.data.errorMessage === '남은 연차 일수가 부족합니다.') {
        const errorMessage = `<div style="font-size: 20px;">${payload.userName}님의 ${error.response?.data.errorMessage}</div> <div style="font-size: 20px;">휴가가 자동으로 반려됩니다.</div>`;

```

다음과 같이, AxiosError값안에 있는 errorMessage값을 얻으려고 각 컴포넌트마다 접근하는데 반복되는 내용 발견

인터셉터에서 error 값을 리턴할 때, erorrMessage를 미리 구조분해 할당해 놓으면 코드의 양을 줄일 수 있을 거 같아서 수정


## 해결방안 

api -> axios -> api.tsx 내에서 인터셉트 리턴값을 구조분해할당해 리턴하도록 수정 

```tsx
export interface ConvertError {
  status: number;
  message: string;
  data: any;
}

const convertErrorResponse = (response: AxiosResponse): ConvertError => {
  return {
    status: response.status ?? 500,
    message: response.data.errorMessage ?? '알 수 없는 에러가 발생했습니다.',
    data: response.data,
  };


apis.interceptors.response.use(
  // 응답을 내보내기 전 수행되는 함수
  function (response) {
    return response;
  },

  // 오류 응답을 내보내기 전 수행되는 함수
  function (error) {
    console.log(error.response);
    return Promise.reject(convertErrorResponse(error.response));
  }
);
};
```